### PR TITLE
Changed style.scss (Google Fonts) to utilize HTTPS connection

### DIFF
--- a/style.scss
+++ b/style.scss
@@ -1,7 +1,7 @@
 ---
 ---
 
-@import url(http://fonts.googleapis.com/css?family=Montserrat:400,700);
+@import url(https://fonts.googleapis.com/css?family=Montserrat:400,700);
 
 /* ------------ Core Style -------------- */
 


### PR DESCRIPTION
Current implementation of Google Fonts causes mixed content/unsecured content warnings for HTTPS secured websites utilizing Taken
